### PR TITLE
Bump elastic.version from 7.7.0 to 7.11.2 in /crawler-service

### DIFF
--- a/crawler-service/pom.xml
+++ b/crawler-service/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<elastic.version>7.7.0</elastic.version>
+		<elastic.version>7.11.2</elastic.version>
 		<lucene.version>8.5.1</lucene.version>
 		<gson.version>2.8.2</gson.version>
 	</properties>


### PR DESCRIPTION
Bumps `elastic.version` from 7.7.0 to 7.11.2.

Updates `elasticsearch` from 7.7.0 to 7.11.2
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.7.0...v7.11.2)

Updates `transport` from 7.7.0 to 7.11.2
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.7.0...v7.11.2)

Updates `elasticsearch-rest-high-level-client` from 7.7.0 to 7.11.2
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.7.0...v7.11.2)

Updates `transport-netty4-client` from 7.7.0 to 7.11.2
- [Release notes](https://github.com/elastic/elasticsearch/releases)
- [Commits](https://github.com/elastic/elasticsearch/compare/v7.7.0...v7.11.2)

Signed-off-by: dependabot[bot] <support@github.com>